### PR TITLE
Fix cart item ID handling and offline fallbacks

### DIFF
--- a/b2b_app/lib/core/models/order_item.dart
+++ b/b2b_app/lib/core/models/order_item.dart
@@ -6,10 +6,20 @@ part 'order_item.g.dart';
 @freezed
 class OrderItem with _$OrderItem {
   const factory OrderItem({
-    required String productId,
-    required int quantity,
-    required double price,
+    @JsonKey(name: 'id') String? id,
+    @JsonKey(name: 'product_id') required String productId,
+    @JsonKey(name: 'quantity') required int quantity,
+    @JsonKey(name: 'price', fromJson: _doubleFromJson, toJson: _doubleToJson)
+        required double price,
   }) = _OrderItem;
 
   factory OrderItem.fromJson(Map<String, dynamic> json) => _$OrderItemFromJson(json);
 }
+
+double _doubleFromJson(Object? value) {
+  if (value == null) return 0;
+  if (value is num) return value.toDouble();
+  return double.parse(value.toString());
+}
+
+Object _doubleToJson(double value) => value;

--- a/b2b_app/lib/core/models/order_item.freezed.dart
+++ b/b2b_app/lib/core/models/order_item.freezed.dart
@@ -9,6 +9,7 @@ OrderItem _$OrderItemFromJson(Map<String, dynamic> json) {
 }
 
 mixin _$OrderItem {
+  String? get id => throw _privateConstructorUsedError;
   String get productId => throw _privateConstructorUsedError;
   int get quantity => throw _privateConstructorUsedError;
   double get price => throw _privateConstructorUsedError;
@@ -20,7 +21,7 @@ mixin _$OrderItem {
 
 abstract class $OrderItemCopyWith<$Res> {
   factory $OrderItemCopyWith(OrderItem value, $Res Function(OrderItem) then) = _$OrderItemCopyWithImpl<$Res>;
-  $Res call({String productId, int quantity, double price});
+  $Res call({String? id, String productId, int quantity, double price});
 }
 
 class _$OrderItemCopyWithImpl<$Res> implements $OrderItemCopyWith<$Res> {
@@ -29,8 +30,9 @@ class _$OrderItemCopyWithImpl<$Res> implements $OrderItemCopyWith<$Res> {
   final $Res Function(OrderItem) _then;
 
   @override
-  $Res call({Object? productId = freezed, Object? quantity = freezed, Object? price = freezed}) {
+  $Res call({Object? id = freezed, Object? productId = freezed, Object? quantity = freezed, Object? price = freezed}) {
     return _then(_value.copyWith(
+      id: id == freezed ? _value.id : id as String?,
       productId: productId == freezed ? _value.productId : productId as String,
       quantity: quantity == freezed ? _value.quantity : quantity as int,
       price: price == freezed ? _value.price : price as double,
@@ -41,7 +43,7 @@ class _$OrderItemCopyWithImpl<$Res> implements $OrderItemCopyWith<$Res> {
 abstract class _$$_OrderItemCopyWith<$Res> implements $OrderItemCopyWith<$Res> {
   factory _$$_OrderItemCopyWith(_OrderItem value, $Res Function(_OrderItem) then) = __$$_OrderItemCopyWithImpl<$Res>;
   @override
-  $Res call({String productId, int quantity, double price});
+  $Res call({String? id, String productId, int quantity, double price});
 }
 
 class __$$_OrderItemCopyWithImpl<$Res> extends _$OrderItemCopyWithImpl<$Res> implements _$$_OrderItemCopyWith<$Res> {
@@ -51,8 +53,9 @@ class __$$_OrderItemCopyWithImpl<$Res> extends _$OrderItemCopyWithImpl<$Res> imp
   _OrderItem get _value => super._value as _OrderItem;
 
   @override
-  $Res call({Object? productId = freezed, Object? quantity = freezed, Object? price = freezed}) {
+  $Res call({Object? id = freezed, Object? productId = freezed, Object? quantity = freezed, Object? price = freezed}) {
     return _then(_OrderItem(
+      id: id == freezed ? _value.id : id as String?,
       productId: productId == freezed ? _value.productId : productId as String,
       quantity: quantity == freezed ? _value.quantity : quantity as int,
       price: price == freezed ? _value.price : price as double,
@@ -62,10 +65,12 @@ class __$$_OrderItemCopyWithImpl<$Res> extends _$OrderItemCopyWithImpl<$Res> imp
 
 @JsonSerializable()
 class _$_OrderItem implements _OrderItem {
-  const _$_OrderItem({required this.productId, required this.quantity, required this.price});
+  const _$_OrderItem({this.id, required this.productId, required this.quantity, required this.price});
 
   factory _$_OrderItem.fromJson(Map<String, dynamic> json) => _$$_OrderItemFromJson(json);
 
+  @override
+  final String? id;
   @override
   final String productId;
   @override
@@ -75,16 +80,17 @@ class _$_OrderItem implements _OrderItem {
 
   @override
   String toString() {
-    return 'OrderItem(productId: $productId, quantity: $quantity, price: $price)';
+    return 'OrderItem(id: $id, productId: $productId, quantity: $quantity, price: $price)';
   }
 
   @override
   bool operator ==(dynamic other) {
-    return identical(this, other) || (other is _OrderItem && other.productId == productId && other.quantity == quantity && other.price == price);
+    return identical(this, other) ||
+        (other is _OrderItem && other.id == id && other.productId == productId && other.quantity == quantity && other.price == price);
   }
 
   @override
-  int get hashCode => Object.hash(productId, quantity, price);
+  int get hashCode => Object.hash(id, productId, quantity, price);
 
   @JsonKey(ignore: true)
   @override
@@ -97,10 +103,12 @@ class _$_OrderItem implements _OrderItem {
 }
 
 abstract class _OrderItem implements OrderItem {
-  const factory _OrderItem({required String productId, required int quantity, required double price}) = _$_OrderItem;
+  const factory _OrderItem({String? id, required String productId, required int quantity, required double price}) = _$_OrderItem;
 
   factory _OrderItem.fromJson(Map<String, dynamic> json) = _$_OrderItem.fromJson;
 
+  @override
+  String? get id;
   @override
   String get productId;
   @override

--- a/b2b_app/lib/core/models/order_item.g.dart
+++ b/b2b_app/lib/core/models/order_item.g.dart
@@ -2,13 +2,15 @@
 part of 'order_item.dart';
 
 _$_OrderItem _$$_OrderItemFromJson(Map<String, dynamic> json) => _$_OrderItem(
-      productId: json['productId'] as String,
+      id: json['id'] as String?,
+      productId: json['product_id'] as String,
       quantity: json['quantity'] as int,
-      price: (json['price'] as num).toDouble(),
+      price: _doubleFromJson(json['price']),
     );
 
 Map<String, dynamic> _$$_OrderItemToJson(_$_OrderItem instance) => <String, dynamic>{
-      'productId': instance.productId,
+      'id': instance.id,
+      'product_id': instance.productId,
       'quantity': instance.quantity,
-      'price': instance.price,
+      'price': _doubleToJson(instance.price),
     };

--- a/b2b_app/lib/features/cart/data/cart_repository.dart
+++ b/b2b_app/lib/features/cart/data/cart_repository.dart
@@ -1,31 +1,75 @@
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'dart:async';
+
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../../../core/models/order_item.dart';
 
 class CartRepository {
   final SupabaseClient _client = Supabase.instance.client;
 
   Stream<List<OrderItem>> watch(String userId) {
-    final stream = _client
+    final source = _client
         .from('cart_items')
         .stream(primaryKey: ['id'])
         .eq('user_id', userId)
         .map((rows) => rows
-            .map((e) => OrderItem.fromJson(e as Map<String, dynamic>))
+            .map((e) =>
+                OrderItem.fromJson(Map<String, dynamic>.from(e as Map)))
             .toList());
-    stream.listen((items) async {
-      final box = await Hive.openBox('cart');
-      await box.put('items', items.map((e) => e.toJson()).toList());
-    });
-    return stream.handleError((_) async {
-      final box = await Hive.openBox('cart');
-      final cached = box.get('items') as List?;
-      if (cached != null) {
-        return cached
-            .map((e) => OrderItem.fromJson(Map<String, dynamic>.from(e)))
-            .toList();
+    final controller = StreamController<List<OrderItem>>();
+
+    Future<Box> openBox() async {
+      if (Hive.isBoxOpen('cart')) {
+        return Hive.box('cart');
+      }
+      return Hive.openBox('cart');
+    }
+
+    Future<bool> emitCached() async {
+      try {
+        final box = await openBox();
+        final cached = box.get('items') as List?;
+        if (cached != null) {
+          final items = cached
+              .map((e) =>
+                  OrderItem.fromJson(Map<String, dynamic>.from(e as Map)))
+              .toList();
+          controller.add(items);
+          return true;
+        }
+      } catch (_) {}
+      return false;
+    }
+
+    final subscription = source.listen((items) async {
+      controller.add(items);
+      try {
+        final box = await openBox();
+        await box.put('items', items.map((e) => e.toJson()).toList());
+      } catch (_) {}
+    }, onError: (error, stackTrace) async {
+      final emitted = await emitCached();
+      if (!emitted) {
+        controller.addError(error, stackTrace);
+      }
+    }, onDone: () async {
+      if (!controller.isClosed) {
+        await controller.close();
       }
     });
+
+    controller
+      ..onPause = () => subscription.pause()
+      ..onResume = () => subscription.resume()
+      ..onCancel = () async {
+        await subscription.cancel();
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      };
+
+    return controller.stream;
   }
 
   Future<void> add(String userId, OrderItem item) async {

--- a/b2b_app/lib/features/cart/logic/cart_controller.dart
+++ b/b2b_app/lib/features/cart/logic/cart_controller.dart
@@ -34,10 +34,21 @@ class CartController extends AsyncNotifier<List<OrderItem>> {
     }
 
     final stream = _repo.watch(_userId!);
+    final completer = Completer<List<OrderItem>>();
     await _subscription?.cancel();
     _subscription = stream.listen(
-      (event) => state = AsyncData(event),
-      onError: (error, stackTrace) => state = AsyncError(error, stackTrace),
+      (event) {
+        if (!completer.isCompleted) {
+          completer.complete(event);
+        }
+        state = AsyncData(event);
+      },
+      onError: (error, stackTrace) {
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+        state = AsyncError(error, stackTrace);
+      },
     );
 
     if (!_disposeRegistered) {
@@ -47,7 +58,7 @@ class CartController extends AsyncNotifier<List<OrderItem>> {
       _disposeRegistered = true;
     }
 
-    return stream.first;
+    return completer.future;
   }
 
   Future<void> addItem(OrderItem item) async {

--- a/b2b_app/lib/features/cart/logic/cart_controller.dart
+++ b/b2b_app/lib/features/cart/logic/cart_controller.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../data/cart_repository.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+
+import '../data/cart_repository.dart';
 import '../../../core/models/order_item.dart';
 
 final cartRepositoryProvider = Provider<CartRepository>((ref) => CartRepository());
@@ -10,17 +13,45 @@ final cartControllerProvider =
 
 class CartController extends AsyncNotifier<List<OrderItem>> {
   late final CartRepository _repo;
-  String get userId => Supabase.instance.client.auth.currentUser!.id;
+  StreamSubscription<List<OrderItem>>? _subscription;
+  String? _userId;
+  bool _disposeRegistered = false;
+
+  String get _resolvedUserId {
+    final id = _userId ?? Supabase.instance.client.auth.currentUser?.id;
+    if (id == null) {
+      throw StateError('No authenticated user available for cart operations');
+    }
+    return id;
+  }
 
   @override
   Future<List<OrderItem>> build() async {
     _repo = ref.read(cartRepositoryProvider);
-    _repo.watch(userId).listen((event) => state = AsyncData(event));
-    return _repo.watch(userId).first;
+    _userId = Supabase.instance.client.auth.currentUser?.id;
+    if (_userId == null) {
+      return const <OrderItem>[];
+    }
+
+    final stream = _repo.watch(_userId!);
+    await _subscription?.cancel();
+    _subscription = stream.listen(
+      (event) => state = AsyncData(event),
+      onError: (error, stackTrace) => state = AsyncError(error, stackTrace),
+    );
+
+    if (!_disposeRegistered) {
+      ref.onDispose(() async {
+        await _subscription?.cancel();
+      });
+      _disposeRegistered = true;
+    }
+
+    return stream.first;
   }
 
   Future<void> addItem(OrderItem item) async {
-    await _repo.add(userId, item);
+    await _repo.add(_resolvedUserId, item);
   }
 
   Future<void> updateQty(String id, int qty) async {
@@ -32,7 +63,7 @@ class CartController extends AsyncNotifier<List<OrderItem>> {
   }
 
   Future<String?> checkout(double total) async {
-    final orderId = await _repo.checkout(userId, total);
+    final orderId = await _repo.checkout(_resolvedUserId, total);
     return orderId;
   }
 }

--- a/b2b_app/lib/features/cart/presentation/cart_page.dart
+++ b/b2b_app/lib/features/cart/presentation/cart_page.dart
@@ -35,10 +35,14 @@ class _CartList extends ConsumerWidget {
             itemCount: items.length,
             itemBuilder: (context, index) {
               final item = items[index];
+              final itemId = item.id;
               return Dismissible(
-                key: ValueKey(item.productId),
-                onDismissed: (_) =>
-                    ref.read(cartControllerProvider.notifier).removeItem(item.productId),
+                key: ValueKey(itemId ?? item.productId),
+                onDismissed: (_) {
+                  if (itemId != null) {
+                    ref.read(cartControllerProvider.notifier).removeItem(itemId);
+                  }
+                },
                 child: ListTile(
                   title: Text(item.productId),
                   subtitle: Row(
@@ -47,10 +51,10 @@ class _CartList extends ConsumerWidget {
                         icon: const Icon(Icons.remove),
                         onPressed: () {
                           final qty = item.quantity - 1;
-                          if (qty > 0) {
+                          if (qty > 0 && itemId != null) {
                             ref
                                 .read(cartControllerProvider.notifier)
-                                .updateQty(item.productId, qty);
+                                .updateQty(itemId, qty);
                           }
                         },
                       ),
@@ -58,9 +62,11 @@ class _CartList extends ConsumerWidget {
                       IconButton(
                         icon: const Icon(Icons.add),
                         onPressed: () {
-                          ref
-                              .read(cartControllerProvider.notifier)
-                              .updateQty(item.productId, item.quantity + 1);
+                          if (itemId != null) {
+                            ref
+                                .read(cartControllerProvider.notifier)
+                                .updateQty(itemId, item.quantity + 1);
+                          }
                         },
                       ),
                     ],

--- a/b2b_app/lib/features/catalog/data/product_repository.dart
+++ b/b2b_app/lib/features/catalog/data/product_repository.dart
@@ -1,5 +1,8 @@
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'dart:async';
+
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
 import '../../../core/models/product.dart';
 
 class ProductRepository {
@@ -13,23 +16,63 @@ class ProductRepository {
         .eq('is_active', true)
         .range(offset, offset + limit - 1)
         .order('name');
-    final stream = builder
+    final source = builder
         .withConverter((rows) =>
             rows.map((e) => Product.fromJson(e as Map<String, dynamic>)).toList())
         .stream();
-    stream.listen((data) async {
-      final box = await Hive.openBox('catalog');
-      await box.put('list', data.map((e) => e.toJson()).toList());
-    });
-    return stream.handleError((_) async {
-      final box = await Hive.openBox('catalog');
-      final cached = box.get('list') as List?;
-      if (cached != null) {
-        return cached
-            .map((e) => Product.fromJson(Map<String, dynamic>.from(e)))
-            .toList();
+    final controller = StreamController<List<Product>>();
+
+    Future<Box> openBox() async {
+      if (Hive.isBoxOpen('catalog')) {
+        return Hive.box('catalog');
+      }
+      return Hive.openBox('catalog');
+    }
+
+    Future<bool> emitCached() async {
+      try {
+        final box = await openBox();
+        final cached = box.get('list') as List?;
+        if (cached != null) {
+          final products = cached
+              .map((e) =>
+                  Product.fromJson(Map<String, dynamic>.from(e as Map)))
+              .toList();
+          controller.add(products);
+          return true;
+        }
+      } catch (_) {}
+      return false;
+    }
+
+    final subscription = source.listen((data) async {
+      controller.add(data);
+      try {
+        final box = await openBox();
+        await box.put('list', data.map((e) => e.toJson()).toList());
+      } catch (_) {}
+    }, onError: (error, stackTrace) async {
+      final emitted = await emitCached();
+      if (!emitted) {
+        controller.addError(error, stackTrace);
+      }
+    }, onDone: () async {
+      if (!controller.isClosed) {
+        await controller.close();
       }
     });
+
+    controller
+      ..onPause = () => subscription.pause()
+      ..onResume = () => subscription.resume()
+      ..onCancel = () async {
+        await subscription.cancel();
+        if (!controller.isClosed) {
+          await controller.close();
+        }
+      };
+
+    return controller.stream;
   }
 
   Future<double> resolvePrice(String sku, String customerId, double basePrice) async {

--- a/b2b_app/lib/features/checkout/data/bnpl_provider.dart
+++ b/b2b_app/lib/features/checkout/data/bnpl_provider.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:io';
+
 import 'package:http/http.dart' as http;
 
 class CreditResult {
@@ -15,9 +17,19 @@ class BnplProvider {
       try {
         final resp = await http.post(
           Uri.parse('https://bnpl.example.com/check-credit'),
+          headers: const {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+          },
           body: jsonEncode({'customerId': customerId}),
         );
-        if (resp.statusCode != 200) throw HttpException('status ${resp.statusCode}');
+        if (resp.statusCode != 200) {
+          developer.log(
+            'BNPL credit check failed with status ${resp.statusCode}: ${resp.body}',
+            name: 'BnplProvider',
+          );
+          throw HttpException('status ${resp.statusCode}');
+        }
         final data = jsonDecode(resp.body) as Map<String, dynamic>;
         return CreditResult(
           (data['limit'] as num).toDouble(),


### PR DESCRIPTION
## Summary
- align OrderItem JSON with Supabase column names so rows expose their id and numeric price consistently
- wrap cart and catalog Supabase streams to cache results and emit stored data on errors while ensuring the cart controller uses a single subscription and passes row ids to mutations
- update the cart UI to operate on row ids and add JSON headers plus logging for BNPL credit checks

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e04e0a33548327a57687fff95ebb84