### PR TITLE
Fix cart controller stream handling and add coverage

### DIFF
--- a/b2b_app/lib/features/cart/logic/cart_controller.dart
+++ b/b2b_app/lib/features/cart/logic/cart_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../data/cart_repository.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -5,18 +7,49 @@ import '../../../core/models/order_item.dart';
 
 final cartRepositoryProvider = Provider<CartRepository>((ref) => CartRepository());
 
+final cartUserIdProvider = Provider<String>((ref) {
+  final user = Supabase.instance.client.auth.currentUser;
+  if (user == null) {
+    throw StateError('No authenticated user found');
+  }
+  return user.id;
+});
+
 final cartControllerProvider =
     AsyncNotifierProvider<CartController, List<OrderItem>>(CartController.new);
 
 class CartController extends AsyncNotifier<List<OrderItem>> {
   late final CartRepository _repo;
-  String get userId => Supabase.instance.client.auth.currentUser!.id;
+  StreamSubscription<List<OrderItem>>? _subscription;
+  String get userId => ref.read(cartUserIdProvider);
 
   @override
   Future<List<OrderItem>> build() async {
     _repo = ref.read(cartRepositoryProvider);
-    _repo.watch(userId).listen((event) => state = AsyncData(event));
-    return _repo.watch(userId).first;
+    _subscription?.cancel();
+    final currentUserId = ref.read(cartUserIdProvider);
+    final completer = Completer<List<OrderItem>>();
+
+    _subscription = _repo.watch(currentUserId).listen(
+      (event) {
+        state = AsyncData(event);
+        if (!completer.isCompleted) {
+          completer.complete(event);
+        }
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        state = AsyncError(error, stackTrace);
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      },
+    );
+
+    ref.onDispose(() {
+      _subscription?.cancel();
+    });
+
+    return completer.future;
   }
 
   Future<void> addItem(OrderItem item) async {

--- a/b2b_app/test/cart_controller_test.dart
+++ b/b2b_app/test/cart_controller_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:b2b_app/core/models/order_item.dart';
+import 'package:b2b_app/features/cart/data/cart_repository.dart';
+import 'package:b2b_app/features/cart/logic/cart_controller.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class _FakeCartRepository extends CartRepository {
+  _FakeCartRepository(this._controller);
+
+  final StreamController<List<OrderItem>> _controller;
+
+  @override
+  Stream<List<OrderItem>> watch(String userId) {
+    return _controller.stream;
+  }
+}
+
+void main() {
+  test('CartController build resolves with first cart items', () async {
+    Supabase.instance.initialize(url: 'u', anonKey: 'k');
+    Supabase.instance.client = SupabaseClient('u', 'k');
+
+    final controller = StreamController<List<OrderItem>>();
+    final repo = _FakeCartRepository(controller);
+
+    final container = ProviderContainer(overrides: [
+      cartRepositoryProvider.overrideWithValue(repo),
+      cartUserIdProvider.overrideWithValue('user-123'),
+    ]);
+
+    addTearDown(() async {
+      await controller.close();
+      container.dispose();
+    });
+
+    final future = container.read(cartControllerProvider.future);
+
+    final items = [
+      const OrderItem(productId: 'p1', quantity: 1, price: 1.0),
+      const OrderItem(productId: 'p2', quantity: 2, price: 3.0),
+    ];
+
+    controller.add(items);
+
+    final initialItems = await future;
+    expect(initialItems, items);
+    expect(container.read(cartControllerProvider).value, items);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure the cart controller reuses a single stream subscription and surfaces the user id through a provider
- complete the initial build from the first stream payload while updating the state from the shared listener
- add a focused test that verifies the controller resolves its initial value and emits the first batch of items

## Testing
- `flutter test test/cart_controller_test.dart` *(fails: flutter not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e053917d308327bd0b75e8bdfef2b2