### PR TITLE
fix: resolve charts_flutter intl dependency conflict

### DIFF
--- a/b2b_app/pubspec.yaml
+++ b/b2b_app/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   firebase_messaging: ^14.7.0
   flutter_stripe: ^9.3.0
   cached_network_image: ^3.3.1
-  charts_flutter: ^0.12.0
+  charts_flutter_fork: ^0.13.3
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   freezed_annotation: ^2.4.1
@@ -29,6 +29,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^4.0.0
   build_runner: ^2.4.7
   freezed: ^2.4.2
   json_serializable: ^6.7.1
@@ -39,4 +40,3 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   generate: true
-


### PR DESCRIPTION
## What  
- Replaced `charts_flutter` with `charts_flutter_fork` to fix an intl version conflict.  
- Ensured `flutter_lints` is listed under dev_dependencies.  

## How to test  
- Run `flutter pub get` in `b2b_app` (the CI will also run `flutter analyze` and `flutter test`).  

## Risks  
- Low; dependency change only.כ