### PR TITLE
Add revenue-focused CTAs and ROI calculator for EVcharge site

### DIFF
--- a/אתר/contact.html
+++ b/אתר/contact.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="he">
 <head>
   <meta charset="UTF-8">
-  <title>Contact | Golden Ace Poker Club</title>
-  <meta name="description" content="Get in touch with Golden Ace Poker Club support team via live chat, email, or the contact form.">
-  <meta name="keywords" content="Contact, Support, Online Poker, Golden Ace, ClubGG, Crypto">
-  <meta name="author" content="Golden Ace Poker Club">
+  <title>צור קשר | EVcharge</title>
+  <meta name="description" content="צרו קשר עם צוות EVcharge לתיאום התקנה, סקר אתר או תמיכה בעמדות טעינה.">
+  <meta name="keywords" content="EVcharge, עמדות טעינה, שירות לקוחות, התקנת עמדות, תמיכה טכנית">
+  <meta name="author" content="EVcharge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <!-- Google Fonts -->
@@ -20,141 +20,168 @@
 <header class="sticky-header">
   <nav class="navbar">
     <div class="logo">
-      <a href="index.html">
-        <img src="images/logo.png" alt="Golden Ace Poker Club Logo">
+      <a href="index.html#top" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
+        <img src="images/logo.png" alt="EVcharge logo">
+        <span class="wordmark">EVcharge.co.il</span>
       </a>
     </div>
 
-    <!-- Burger Menu (Mobile) -->
     <div class="burger" id="burger-menu">
       <div class="line1"></div>
       <div class="line2"></div>
       <div class="line3"></div>
     </div>
 
-    <!-- Dropdown Nav Links -->
     <ul class="nav-links" id="nav-links">
-      <li><a href="index.html">Home</a></li>
-      
-      <li class="has-dropdown">
-        <a href="#">The Club</a>
-        <ul class="dropdown">
-          <li><a href="news.html">News</a></li>
-          <li><a href="join-club.html">Join the Club</a></li>
-          <li><a href="club-guide.html">Club Guide</a></li>
-        </ul>
-      </li>
-      
-      <li class="has-dropdown">
-        <a href="#">Getting Started</a>
-        <ul class="dropdown">
-          <li><a href="how-to-install.html">How to Install</a></li>
-          <li><a href="faq.html">FAQ</a></li>
-        </ul>
-      </li>
-
-      <li class="has-dropdown">
-        <a href="#">Payment</a>
-        <ul class="dropdown">
-          <li><a href="crypto-payment.html">Crypto Payment</a></li>
-          <li><a href="withdrawal.html">Withdrawal</a></li>
-        </ul>
-      </li>
-
-      <li class="has-dropdown">
-        <a href="#">Policies</a>
-        <ul class="dropdown">
-          <li><a href="terms.html">Terms</a></li>
-          <li><a href="privacy.html">Privacy</a></li>
-          <li><a href="responsible-gaming.html">Responsible Gaming</a></li>
-        </ul>
-      </li>
-
-      <li><a href="contact.html" class="active">Contact</a></li>
+      <li><a href="index.html#top">בית</a></li>
+      <li><a href="index.html#solutions">פתרונות</a></li>
+      <li><a href="index.html#plans">חבילות</a></li>
+      <li><a href="index.html#process">איך זה עובד</a></li>
+      <li><a href="contact.html" class="active">צור קשר</a></li>
     </ul>
   </nav>
 </header>
 
-<!-- באנר עם contact-bg.webp -->
+<section class="cta-strip fade-in-on-scroll">
+  <div class="strip-content">
+    <div>
+      <div class="strip-title">צריכים לסגור התקנה דחופה?</div>
+      <p class="strip-subtitle">צוות המכירות שלנו מחזיר תשובה עם מחיר וזמני התקנה תוך 60 דקות.</p>
+    </div>
+    <div class="strip-actions">
+      <a class="btn-cta" href="#contact-form">הצעת מחיר מהירה</a>
+      <a class="btn-secondary" href="tel:0730000000">073-000-0000</a>
+      <span class="response-tag">מענה 15 דק' בשעות הפעילות</span>
+    </div>
+  </div>
+</section>
+
 <section class="page-banner hero-contact fade-in-on-load">
-  <h1>Contact Us</h1>
+  <h1>דברו עם מומחה EVcharge</h1>
+  <p class="lead-paragraph" style="margin:auto; max-width:720px;">נחזור אליכם במהירות עם תשובות, הצעת מחיר או תיאום ביקור באתר. זמינים בטלפון, מייל או צ'אט.</p>
 </section>
 
 <section class="page-content fade-in-on-scroll">
-  <h2>We’re Here to Help</h2>
-  <p>
-    Need assistance or have questions about joining, payments, tournaments, or anything else? 
-    Our support team is here to ensure your Golden Ace experience is smooth. 
-    You can reach us via live chat (bottom-right corner) or by filling out the form below.
-  </p>
+  <div class="two-column">
+    <div>
+      <div class="section-heading">דרכי התקשרות</div>
+      <h2>בחרו את הדרך הנוחה לכם</h2>
+      <ul class="list-check">
+        <li><strong>טלפון:</strong> 073-000-0000 (ימים א'-ה', 9:00-18:00)</li>
+        <li><strong>אימייל:</strong> hello@evcharge.co.il</li>
+        <li><strong>צ'אט:</strong> זמינות 24/7 דרך החלון בתחתית העמוד.</li>
+      </ul>
+      <p class="lead-paragraph">לקבלת הצעת מחיר, מומלץ למלא את הטופס ולהוסיף כמה עמדות אתם צריכים ומה סוג החניה.</p>
+      <div class="cta-row">
+        <a class="btn-cta" href="#contact-form">טופס הצעת מחיר</a>
+        <a class="btn-secondary" href="index.html#plans">ראה חבילות</a>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="badge">SLA & שירות</div>
+      <p class="tagline">שירותי ניטור, תחזוקה ותמיכה מרחוק לכלל העמדות המותקנות.</p>
+      <ul class="pill-list">
+        <li>ניטור 24/7</li>
+        <li>תחזוקה מונעת</li>
+        <li>הדרכת צוותים</li>
+        <li>דוחות שימוש</li>
+        <li>מענה מהיר SLA</li>
+      </ul>
+    </div>
+  </div>
 </section>
 
 <section class="page-content fade-in-on-scroll">
-  <h2>Contact Form</h2>
-  <form action="server/send-form.php" method="POST" class="styled-form">
-    <label for="contactName">Name:</label>
-    <input type="text" id="contactName" name="contactName" required>
-
-    <label for="contactEmail">Email:</label>
-    <input type="email" id="contactEmail" name="contactEmail" required>
-
-    <label for="topic">Topic (optional):</label>
-    <select id="topic" name="topic">
-      <option value="">--Choose a topic--</option>
-      <option value="General Inquiry">General Inquiry</option>
-      <option value="Technical Issue">Technical Issue</option>
-      <option value="Payment/Deposit">Payment / Deposit</option>
-      <option value="Withdrawal">Withdrawal</option>
-      <option value="Join Club">Join Club</option>
-      <option value="Other">Other</option>
-    </select>
-
-    <label for="message">Message:</label>
-    <textarea id="message" name="message" rows="6" required></textarea>
-
-    <button type="submit">Send</button>
-  </form>
-  <p>
-    We aim to respond within 24 hours. Meanwhile, you can also check out our 
-    <a href="faq.html">FAQ</a> for quick answers.
-  </p>
+  <div class="panel">
+    <div class="section-heading">שיחת מכירה מהירה</div>
+    <h2>קובעים זמן לשיחה – אנחנו חוזרים עם מחיר</h2>
+    <form class="quote-form" action="server/send-form.php" method="POST">
+      <div>
+        <label for="fastName">שם מלא</label>
+        <input type="text" id="fastName" name="fastName" placeholder="רותם כהן" required>
+      </div>
+      <div>
+        <label for="fastPhone">טלפון</label>
+        <input type="tel" id="fastPhone" name="fastPhone" placeholder="050-0000000" required>
+      </div>
+      <div>
+        <label for="fastTiming">שעת חזרה מועדפת</label>
+        <select id="fastTiming" name="fastTiming">
+          <option value="">בחרו</option>
+          <option value="בוקר">בוקר (9:00-12:00)</option>
+          <option value="צהריים">צהריים (12:00-15:00)</option>
+          <option value="אחר הצהריים">אחר הצהריים (15:00-18:00)</option>
+        </select>
+      </div>
+      <div>
+        <label for="fastNeed">מה אנחנו צריכים לדעת?</label>
+        <input type="text" id="fastNeed" name="fastNeed" placeholder="כמות עמדות / סוג נכס / תקציב" required>
+      </div>
+      <div class="full-span" style="display:flex;align-items:center;gap:8px;">
+        <input type="checkbox" id="fastConsent" name="fastConsent" required style="width:auto;">
+        <label for="fastConsent" style="margin:0;">מאשר/ת יצירת קשר ושליחת הצעה</label>
+      </div>
+      <div class="full-span">
+        <button type="submit" class="btn-cta" style="width:100%;justify-content:center;">קבעו שיחה</button>
+      </div>
+    </form>
+  </div>
 </section>
 
-<section class="page-content fade-in-on-scroll">
-  <h2>Alternative Ways to Reach Us</h2>
-  <ul style="line-height:1.8;">
-    <li><strong>Live Chat:</strong> Look for the chat icon in the bottom-right corner. 
-      (Available 10 AM – 2 AM UTC)</li>
-    <li><strong>Email Support:</strong> If you prefer direct email, send inquiries to 
-      <em>support@goldenacepoker.com</em> (replace with your actual email).
-    </li>
-    <li><strong>News Page:</strong> For updates on tournaments and events, check 
-      our <a href="news.html">News page</a>.</li>
-  </ul>
-  <p>
-    We appreciate your interest in Golden Ace Poker Club and look forward to helping you!
-  </p>
+<section id="contact-form" class="page-content fade-in-on-scroll">
+  <div class="panel">
+    <div class="section-heading">טופס ליד</div>
+    <h2>ספרו לנו מה אתם צריכים</h2>
+    <form action="server/send-form.php" method="POST" class="quote-form">
+      <div>
+        <label for="contactName">שם</label>
+        <input type="text" id="contactName" name="contactName" required>
+      </div>
+      <div>
+        <label for="contactPhone">טלפון</label>
+        <input type="tel" id="contactPhone" name="contactPhone" required>
+      </div>
+      <div>
+        <label for="contactEmail">אימייל</label>
+        <input type="email" id="contactEmail" name="contactEmail" required>
+      </div>
+      <div>
+        <label for="contactTopic">סוג נכס</label>
+        <select id="contactTopic" name="contactTopic">
+          <option value="">בחרו</option>
+          <option value="בית פרטי">בית פרטי</option>
+          <option value="עסק/משרד">עסק / משרד</option>
+          <option value="חניון">חניון</option>
+          <option value="צי רכב">צי רכב</option>
+        </select>
+      </div>
+      <div class="full-span">
+        <label for="contactMessage">פרטים נוספים</label>
+        <textarea id="contactMessage" name="contactMessage" rows="5" placeholder="כמות עמדות, מועד התקנה, מגבלות חשמל"></textarea>
+      </div>
+      <div class="full-span">
+        <button type="submit" class="btn-cta" style="width:100%; justify-content:center;">שלחו לי הצעה</button>
+      </div>
+    </form>
+  </div>
 </section>
 
 <footer>
-  <div style="text-align:center; padding: 20px; background-color: #111;">
-    <p>&copy; 2025 Golden Ace Poker Club. All rights reserved.</p>
-    <p>Powered by <strong>ClubGG</strong> | <a href="contact.html" style="color:#ffd700;">Contact Support</a></p>
+  <div style="text-align:center; padding: 20px; background-color: #0f1621; border-top:1px solid var(--border);">
+    <p>&copy; 2025 EVcharge.co.il. כל הזכויות שמורות.</p>
+    <p>זקוקים למענה מהיר? התקשרו או שלחו מייל ל-hello@evcharge.co.il</p>
     <p>
-      <a href="index.html" style="color:#fff; margin-right:10px;">Home</a> | 
-      <a href="join-club.html" style="color:#fff; margin-right:10px;">Join Now</a> | 
-      <a href="faq.html" style="color:#fff; margin-right:10px;">FAQ</a> | 
-      <a href="terms.html" style="color:#fff;">Terms</a>
+      <a href="index.html#top" style="color:#fff; margin-right:10px;">בית</a> |
+      <a href="index.html#solutions" style="color:#fff; margin-right:10px;">פתרונות</a> |
+      <a href="index.html#plans" style="color:#fff; margin-right:10px;">חבילות</a> |
+      <a href="contact.html" style="color:#fff;">צור קשר</a>
     </p>
   </div>
 </footer>
 
-<!-- כפתור חזרה למעלה -->
 <button id="backToTopBtn" title="Go to top">↑</button>
 
 <script src="js/script.js"></script>
-
-<!-- Tawk.to Chat Script -->
 <script type="text/javascript">
 var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
 (function(){
@@ -166,6 +193,5 @@ s1.setAttribute('crossorigin','*');
 s0.parentNode.insertBefore(s1,s0);
 })();
 </script>
-
 </body>
 </html>

--- a/אתר/css/style.css
+++ b/אתר/css/style.css
@@ -1,16 +1,31 @@
 /* style.css */
 
+:root {
+  --bg: #0a0f14;
+  --surface: #0f1824;
+  --panel: #131c28;
+  --muted: #b8c7e0;
+  --text: #e6f1ff;
+  --accent: #2ddf6c;
+  --accent-2: #60e7ff;
+  --border: #1f2b3a;
+  --shadow: 0 18px 60px rgba(0, 0, 0, 0.35);
+}
+
 /* Google Font (Poppins) כבר נטען ב-HTML, אנחנו רק משתמשים בו */
 body, input, textarea, select, button {
   font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  color: #fff;
+  color: var(--text);
 }
 
 body {
-  background-color: #000; /* רקע שחור כללי */
+  background: radial-gradient(circle at 15% 20%, rgba(45, 223, 108, 0.08), transparent 25%),
+              radial-gradient(circle at 80% 10%, rgba(96, 231, 255, 0.12), transparent 22%),
+              var(--bg);
+  padding-bottom: 80px; /* מקום לבר קבע CTA */
 }
 
 /* === HEADER / NAVBAR === */
@@ -18,26 +33,41 @@ body {
   position: sticky;
   top: 0;
   z-index: 999;
-  background-color: #111;
+  background-color: rgba(15, 24, 36, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
 }
 
 /* מיכל שמחזיק את הכל במרכז, מגביל רוחב, וממרכז */
 .navbar {
   display: flex;
   align-items: center;
-  justify-content: center; 
+  justify-content: space-between;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 10px 20px;
+  padding: 12px 24px;
   position: relative; /* כדי שנוכל למקם בורגר וכו' */
+  gap: 18px;
 }
 
 .logo {
-  margin-right: 50px; /* רווח בין הלוגו לתפריט */
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.5px;
 }
 
 .logo img {
-  height: 50px;
+  height: 48px;
+  width: auto;
+}
+
+.logo .wordmark {
+  display: block;
+  font-size: 16px;
+  color: var(--text);
 }
 
 /* רשימת קישורים */
@@ -45,7 +75,7 @@ body {
   list-style: none;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 18px;
   transition: height 0.3s ease;
   position: relative;
 }
@@ -54,13 +84,14 @@ body {
 .nav-links li a {
   text-decoration: none;
   font-weight: 500;
-  color: #fff;
-  transition: color 0.3s;
+  color: var(--muted);
+  transition: color 0.3s, opacity 0.3s;
 }
 
 .nav-links li a:hover,
 .nav-links li a.active {
-  color: #ffd700; /* זהב */
+  color: #fff;
+  opacity: 1;
 }
 
 /* בורגר (למובייל) */
@@ -83,7 +114,7 @@ body {
 /* מדיה קווארי: מובייל */
 @media (max-width: 768px) {
   .burger {
-    display: block; 
+    display: block;
   }
 
   /* במובייל נשים את .nav-links בהצגה מוסתרת עד שהמשתמש פותח (expanded) */
@@ -92,7 +123,7 @@ body {
     top: 60px;
     right: 0;
     flex-direction: column;
-    background-color: #111;
+    background-color: var(--panel);
     width: 200px;
     height: 0;
     overflow: hidden;
@@ -114,7 +145,7 @@ body {
 
 /* dropdown מוסתר בברירת מחדל, ממוקם מתחת לפריט האב (top:100%) */
 .nav-links li.has-dropdown .dropdown {
-  background-color: #111;
+  background-color: var(--panel);
   position: absolute;
   top: 100%;
   left: 0;
@@ -130,12 +161,12 @@ body {
 .nav-links li.has-dropdown .dropdown li a {
   padding: 10px;
   display: block;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid var(--border);
   text-decoration: none;
   color: #fff;
 }
 .nav-links li.has-dropdown .dropdown li a:hover {
-  background-color: #222;
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 /* Hover בדסקטופ (מסכים רחבים), מציג dropdown */
@@ -151,7 +182,7 @@ body {
     position: static;
     background-color: inherit;
     border: none;
-    display: none; 
+    display: none;
   }
   .nav-links.expanded li.has-dropdown .dropdown {
     display: flex;
@@ -166,20 +197,99 @@ body {
 /* === תוכן כללי === */
 .page-content {
   padding: 40px 20px;
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
   line-height: 1.6;
+  color: var(--text);
+}
+
+.section-heading {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 12px;
+  color: var(--accent);
+  background: rgba(45, 223, 108, 0.08);
+  padding: 6px 12px;
+  border: 1px solid rgba(45, 223, 108, 0.25);
+  border-radius: 999px;
+}
+
+.lead-paragraph {
+  color: var(--muted);
+  max-width: 760px;
+  margin: 12px auto 0;
+}
+
+.highlight {
+  color: var(--accent);
+}
+
+.btn-cta,
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-weight: 700;
+  text-decoration: none;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+}
+
+.btn-cta {
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #0a0f14;
+  box-shadow: var(--shadow);
+}
+
+.btn-cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 40px rgba(45, 223, 108, 0.35);
+}
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--border);
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 /* Hero / Banner */
 .hero {
-  text-align: center;
-  padding: 100px 20px;
+  text-align: left;
+  padding: 110px 20px;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
   background-blend-mode: multiply;
-  background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6));
+  background: radial-gradient(circle at 20% 20%, rgba(45, 223, 108, 0.2), transparent 35%),
+              radial-gradient(circle at 80% 20%, rgba(96, 231, 255, 0.2), transparent 32%),
+              linear-gradient(145deg, #0b1320 0%, #08111a 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 60% 40%, rgba(255, 255, 255, 0.06), transparent 40%);
+  pointer-events: none;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
 }
 
 /* page-banner -> בשאר העמודים שמחליף את hero */
@@ -190,13 +300,14 @@ body {
   background-position: center;
   background-repeat: no-repeat;
   background-blend-mode: multiply;
-  background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6));
+  background: linear-gradient(145deg, #0b1320 0%, #08111a 100%);
 }
 
 /* דוגמאות לשמות מחלקות עבור תמונות: hero-home, hero-news וכו' */
 .hero-home {
-  background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)), 
-              url("images/hero-bg.webp") no-repeat center center;
+  background: radial-gradient(circle at 15% 20%, rgba(45, 223, 108, 0.18), transparent 35%),
+              radial-gradient(circle at 75% 10%, rgba(96, 231, 255, 0.18), transparent 30%),
+              linear-gradient(145deg, #0b1320 0%, #0a141f 50%, #0b1626 100%);
 }
 .hero-news {
   background-image: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
@@ -239,8 +350,322 @@ body {
                     url("images/responsible-gaming.webp");
 }
 .hero-contact {
-  background-image: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)),
-                    url("images/contact-bg.webp");
+  background: radial-gradient(circle at 15% 20%, rgba(45, 223, 108, 0.18), transparent 35%),
+              radial-gradient(circle at 75% 10%, rgba(96, 231, 255, 0.18), transparent 30%),
+              linear-gradient(145deg, #0b1320 0%, #0a141f 50%, #0b1626 100%);
+}
+
+/* === Layout blocks === */
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+  margin-top: 24px;
+}
+
+.content-grid.three-col {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: rgba(45, 223, 108, 0.12);
+  color: var(--accent);
+  border: 1px solid rgba(45, 223, 108, 0.2);
+}
+
+.cta-strip {
+  background: linear-gradient(90deg, rgba(45, 223, 108, 0.08), rgba(96, 231, 255, 0.05));
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  padding: 18px 16px;
+}
+
+.strip-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.strip-title {
+  font-weight: 700;
+  font-size: 18px;
+}
+
+.strip-subtitle {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.strip-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.response-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(96, 231, 255, 0.12);
+  border: 1px solid rgba(96, 231, 255, 0.25);
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+.pill-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+  margin: 16px 0 0;
+  list-style: none;
+}
+
+.pill-list li {
+  background: rgba(96, 231, 255, 0.08);
+  color: var(--text);
+  border: 1px solid rgba(96, 231, 255, 0.25);
+  padding: 8px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.stat {
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.stat .value {
+  font-size: 26px;
+  font-weight: 700;
+  color: #fff;
+}
+
+.stat .label {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.step {
+  padding: 18px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+}
+
+.step-number {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 10px;
+  background: rgba(45, 223, 108, 0.14);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  align-items: start;
+  margin-top: 16px;
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 20px;
+  box-shadow: var(--shadow);
+}
+
+.revenue-card {
+  border: 1px solid rgba(45, 223, 108, 0.25);
+  background: linear-gradient(180deg, rgba(45, 223, 108, 0.06), rgba(15, 24, 36, 0.95));
+}
+
+.calculator {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.calc-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px 14px;
+}
+
+.calc-form input,
+.calc-form label,
+.calc-form select {
+  width: 100%;
+}
+
+.calc-form input,
+.calc-form select {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.02);
+  color: #fff;
+}
+
+.calc-result {
+  background: rgba(96, 231, 255, 0.06);
+  border: 1px solid rgba(96, 231, 255, 0.25);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.result-number {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(45, 223, 108, 0.14);
+  border-radius: 999px;
+  color: var(--text);
+  border: 1px solid rgba(45, 223, 108, 0.25);
+  font-size: 13px;
+}
+
+.list-check {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+}
+
+.list-check li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
+  color: var(--muted);
+}
+
+.list-check li::before {
+  content: "✔";
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.quote-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px 16px;
+}
+
+.quote-form label {
+  font-weight: 600;
+  color: #fff;
+}
+
+.quote-form input,
+.quote-form select,
+.quote-form textarea {
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  color: #fff;
+}
+
+.quote-form textarea {
+  min-height: 120px;
+}
+
+.quote-form .full-span {
+  grid-column: 1 / -1;
+}
+
+.tagline {
+  color: var(--muted);
+  margin-top: 10px;
+}
+
+.testimonials {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(96, 231, 255, 0.2);
+  background: linear-gradient(180deg, rgba(96, 231, 255, 0.04), rgba(13, 18, 27, 0.95));
+}
+
+.testimonial-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--muted);
 }
 
 /* === Fade-In Animations === */
@@ -278,6 +703,27 @@ body {
   background-color: #e6c200;
 }
 
+.sticky-cta-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(10, 15, 20, 0.92);
+  border-top: 1px solid var(--border);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  z-index: 90;
+  backdrop-filter: blur(10px);
+}
+
+.sticky-cta-bar .cta-row {
+  margin: 0;
+}
+
 /* טפסים וכלי עזר (.styled-form) */
 .styled-form {
   display: flex;
@@ -291,22 +737,23 @@ body {
 .styled-form input,
 .styled-form select,
 .styled-form textarea {
-  padding: 10px;
-  border: 1px solid #444;
-  border-radius: 4px;
-  background-color: #222;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.03);
   color: #fff;
 }
 .styled-form button {
-  background-color: #ffd700;
-  color: #000;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  color: #0a0f14;
   border: none;
   padding: 12px;
-  border-radius: 4px;
-  font-weight: 600;
+  border-radius: 10px;
+  font-weight: 700;
   cursor: pointer;
-  transition: background-color 0.3s;
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
 }
 .styled-form button:hover {
-  background-color: #e6c200;
+  transform: translateY(-1px);
+  box-shadow: 0 15px 40px rgba(45, 223, 108, 0.35);
 }

--- a/אתר/index.html
+++ b/אתר/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="he">
 <head>
   <meta charset="UTF-8">
-  <title>Golden Ace Poker Club</title>
-  <meta name="description" content="Join the ultimate Golden Ace Poker Club on ClubGG. Enjoy tournaments, secure crypto payments, and a vibrant poker community.">
-  <meta name="keywords" content="Poker, Online Poker, Golden Ace, ClubGG, Crypto Payment, Tournaments, Secure, Community">
-  <meta name="author" content="Golden Ace Poker Club">
+  <title>EVcharge | עמדות טעינה חכמות לעסקים, בתים ומתחמי חניה</title>
+  <meta name="description" content="הקמה והפעלה של עמדות טעינה חכמות עם התקנה מהירה, גבייה אוטומטית ושרות 24/7. פתרונות לבית, לעסק, לחניונים ולצי רכב.">
+  <meta name="keywords" content="עמדות טעינה, רכב חשמלי, EV, טעינה חכמה, הקמת חניון, evcharge.co.il, התקנת עמדות">
+  <meta name="author" content="EVcharge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  
+
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
@@ -15,137 +15,448 @@
   <!-- Main CSS -->
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body>
+<body id="top">
 
 <header class="sticky-header">
   <nav class="navbar">
     <div class="logo">
-      <a href="index.html">
-        <img src="images/logo.png" alt="Golden Ace Poker Club Logo">
+      <a href="#top" style="display:flex;align-items:center;gap:10px;text-decoration:none;">
+        <img src="images/logo.png" alt="EVcharge logo">
+        <span class="wordmark">EVcharge.co.il</span>
       </a>
     </div>
 
-    <!-- אייקון בורגר לנייד -->
     <div class="burger" id="burger-menu">
       <div class="line1"></div>
       <div class="line2"></div>
       <div class="line3"></div>
     </div>
 
-    <!-- תפריט עליון ראשי עם dropdown ב-hover (למסכים גדולים) -->
     <ul class="nav-links" id="nav-links">
-      <li><a href="index.html" class="active">Home</a></li>
-      
-      <!-- The Club dropdown -->
-      <li class="has-dropdown">
-        <a href="#">The Club</a>
-        <ul class="dropdown">
-          <li><a href="news.html">News</a></li>
-          <li><a href="join-club.html">Join the Club</a></li>
-          <li><a href="club-guide.html">Club Guide</a></li>
-        </ul>
-      </li>
-
-      <!-- Getting Started dropdown -->
-      <li class="has-dropdown">
-        <a href="#">Getting Started</a>
-        <ul class="dropdown">
-          <li><a href="how-to-install.html">How to Install</a></li>
-          <li><a href="faq.html">FAQ</a></li>
-        </ul>
-      </li>
-
-      <!-- Payment dropdown -->
-      <li class="has-dropdown">
-        <a href="#">Payment</a>
-        <ul class="dropdown">
-          <li><a href="crypto-payment.html">Crypto Payment</a></li>
-          <li><a href="withdrawal.html">Withdrawal</a></li>
-        </ul>
-      </li>
-
-      <!-- Policies dropdown -->
-      <li class="has-dropdown">
-        <a href="#">Policies</a>
-        <ul class="dropdown">
-          <li><a href="terms.html">Terms</a></li>
-          <li><a href="privacy.html">Privacy</a></li>
-          <li><a href="responsible-gaming.html">Responsible Gaming</a></li>
-        </ul>
-      </li>
-
-      <!-- Contact standalone -->
-      <li><a href="contact.html">Contact</a></li>
+      <li><a href="#top" class="active">בית</a></li>
+      <li><a href="#solutions">פתרונות</a></li>
+      <li><a href="#industries">סקטורים</a></li>
+      <li><a href="#plans">חבילות</a></li>
+      <li><a href="#process">איך זה עובד</a></li>
+      <li><a href="#quote">צור קשר</a></li>
     </ul>
   </nav>
 </header>
 
 <section class="hero hero-home fade-in-on-load">
-  <h1>Welcome to Golden Ace Poker Club</h1>
-  <p>
-    Experience the thrill of online poker in a world-class environment. At Golden Ace Poker Club, 
-    we provide daily tournaments, private tables, competitive gameplay, and a secure crypto 
-    payment system—all on the robust <strong>ClubGG</strong> platform.
+  <div class="page-content">
+    <div class="badge">חדש בישראל · EVcharge</div>
+    <h1>עמדות טעינה שמייצרות הכנסה ויוצרות חוויית משתמש מושלמת</h1>
+    <p class="lead-paragraph">
+      תכנון, התקנה והפעלה של עמדות טעינה חכמות בבית, בעסק, בחניונים וברשתות קמעונאיות. גבייה אוטומטית, ניטור בזמן אמת ושירות 24/7 – עם זמני התקנה של עד 7 ימי עסקים.
+    </p>
+    <div class="cta-row">
+      <a class="btn-cta" href="#quote">הצעת מחיר מהירה</a>
+      <a class="btn-secondary" href="#process">פירוט תהליך ההתקנה</a>
+    </div>
+    <div class="stat-grid" style="margin-top:28px;">
+      <div class="stat">
+        <div class="value">7 ימים</div>
+        <div class="label">זמן ממוצע לאספקה והתקנה</div>
+      </div>
+      <div class="stat">
+        <div class="value">+98%</div>
+        <div class="label">זמינות מערכת וניטור</div>
+      </div>
+      <div class="stat">
+        <div class="value">120%</div>
+        <div class="label">גידול בהכנסות חניונים היברידיים</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="cta-strip fade-in-on-scroll">
+  <div class="strip-content">
+    <div>
+      <div class="strip-title">הכנסה כבר מהחודש הראשון</div>
+      <p class="strip-subtitle">מודל RevShare או CAPEX, תמורה מובטחת עם SLA מענה מהיר.</p>
+    </div>
+    <div class="strip-actions">
+      <a class="btn-cta" href="#quote">חוזרים אליכם תוך 60 דקות</a>
+      <a class="btn-secondary" href="tel:0730000000">דברו עם נציג 073-000-0000</a>
+      <span class="response-tag">מענה 15 דק' בשעות הפעילות</span>
+    </div>
+  </div>
+</section>
+
+<section id="solutions" class="page-content fade-in-on-scroll">
+  <div class="section-heading">פתרונות טעינה</div>
+  <h2>מהיר, אמין ורווחי בכל סוג נכס</h2>
+  <p class="lead-paragraph">
+    התאמה מלאה לצרכי הנכס, יכולת חיוב לפי דקה או kWh, שילוב תשלומי אשראי ו-Apple/Google Pay, ומערכת דוחות בזמן אמת למנהלים.
   </p>
-  <a class="btn-cta" href="how-to-install.html">Get Started</a>
+  <div class="content-grid">
+    <div class="card">
+      <h3>בתים פרטיים ובניינים</h3>
+      <p>עמדות AC חכמות עם איזון עומסים, שליטה מאפליקציה, והתקנה נקייה כולל תשתית חשמלית ומיגון.</p>
+      <ul class="list-check">
+        <li>תמיכה בעמדות 7.4kW–22kW</li>
+        <li>ניהול משתמשים לבניינים משותפים</li>
+        <li>שילוב מנגנון חיוב לפי שימוש</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>עסקים ומשרדים</h3>
+      <p>הטענה לעובדים ואורחים, עם דשבורד חכם, מגבלות זמן והנחות לעובדים. עיצוב מותאם מותג.</p>
+      <ul class="list-check">
+        <li>סליקה אוטומטית והפקת חשבוניות</li>
+        <li>זמינות SLA ותחזוקה מונעת</li>
+        <li>מדיניות חניה וטעינה לפי שעות</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3>חניונים, מלונות וקניונים</h3>
+      <p>פריסת עמדות AC/DC, מיתוג מלא, והפעלה כעסק מניב עם תמחור דינמי בהתאם לתפוסה ולשעות עומס.</p>
+      <ul class="list-check">
+        <li>תמחור מבוסס ביקוש ופרקי זמן</li>
+        <li>API לדיווח וממשקי BI</li>
+        <li>צוות ניטור 24/7 והתראה בזמן אמת</li>
+      </ul>
+    </div>
+  </div>
 </section>
 
 <section class="page-content fade-in-on-scroll">
-  <h2>Why Choose Golden Ace?</h2>
-  <ul style="line-height:1.8;">
-    <li><strong>Exclusive Online Poker Community:</strong> We handpick our members to maintain a respectful, 
-      fair-play atmosphere with real contenders at every table.</li>
-    <li><strong>Daily Tournaments &amp; Events:</strong> Whether you’re a beginner or a pro, our wide range of 
-      buy-ins and formats keeps the action fresh and exciting every single day.</li>
-    <li><strong>Secure Crypto Payments:</strong> Enjoy seamless deposits and withdrawals using Bitcoin, Ethereum, 
-      and other popular cryptocurrencies—fast, global, and trusted.</li>
-    <li><strong>Advanced Platform:</strong> Built on <em>ClubGG</em>, our club ensures stability, anti-cheating measures, 
-      and a polished user interface for both mobile and desktop.</li>
-    <li><strong>24/7 Support:</strong> Our dedicated team is here to assist you around the clock via live chat 
-      or email. We value quick responses to keep you focused on the game.</li>
-  </ul>
+  <div class="section-heading">מכונת הכנסה</div>
+  <h2>צוות מכירות + פריסה + סליקה = כסף בבנק</h2>
+  <div class="content-grid three-col">
+    <div class="card revenue-card">
+      <div class="badge">Onboarding</div>
+      <h3>תסריטי סגירה מוכנים</h3>
+      <p>מכניסים את הנכס שלכם למסלול מכירות מובנה: סקר אתר, הערכת עומסים, והצעת מחיר חתומה בתוך יומיים.</p>
+      <ul class="list-check">
+        <li>קובץ מסחור מוכן לשימוש</li>
+        <li>סימולציית הכנסות לפי תנועה</li>
+        <li>הצעת מחיר חתימה דיגיטלית</li>
+      </ul>
+    </div>
+    <div class="card revenue-card">
+      <div class="badge">תפעול</div>
+      <h3>חיוב אוטומטי + מיתוג</h3>
+      <p>מערכת סליקה מלאה עם Apple/Google Pay, מדיניות חיוב גמישה והודעות דחיפה למשתמשים חוזרים.</p>
+      <ul class="list-check">
+        <li>קידום עמדות באפליקציה</li>
+        <li>קופונים ומבצעי פתיחה</li>
+        <li>דוחות הכנסה בזמן אמת</li>
+      </ul>
+    </div>
+    <div class="card revenue-card">
+      <div class="badge">שימור</div>
+      <h3>מעגל לקוחות חוזרים</h3>
+      <p>שכבת נאמנות, שעות שיא מתומחרות, ומסרי SMS/Push שמחזירים נהגים להטעין אצלכם.</p>
+      <ul class="list-check">
+        <li>מועדון נהגים עסקי</li>
+        <li>מודול עמלות לשותפים</li>
+        <li>דו"ח חודשי כולל Rebill</li>
+      </ul>
+    </div>
+  </div>
+  <div class="cta-row" style="margin-top:24px;">
+    <a class="btn-cta" href="#quote">התחילו סקר הכנסות</a>
+    <a class="btn-secondary" href="#plans">בחרו חבילה</a>
+  </div>
+</section>
+
+<section id="industries" class="page-content fade-in-on-scroll">
+  <div class="two-column">
+    <div>
+      <div class="section-heading">יתרונות תפעוליים</div>
+      <h2>מיקסום הכנסות, מינימום כאבי ראש</h2>
+      <p class="lead-paragraph">מערכת ניהול מרכזית, חשבוניות אוטומטיות ותמיכה ב-OCPP מאפשרים לנו להפעיל מגוון עמדות ולהתחבר ל-HMS או לפלטפורמות קיימות.</p>
+      <ul class="list-check">
+        <li>שכבות אבטחה והגנת עומסים למניעת נפילות.</li>
+        <li>שירות התקנות בפריסה ארצית עם צוותים ייעודיים.</li>
+        <li>גיבוי סוללה ואופציית UPS לחניונים רגישים.</li>
+        <li>חיבור אוטומטי למערכות הנה"ח ודוחות התאמה.</li>
+      </ul>
+      <div class="cta-row">
+        <a class="btn-cta" href="#quote">נקבע סקר אתר</a>
+        <a class="btn-secondary" href="#plans">צפו בחבילות</a>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="badge">מודל עסקי</div>
+      <h3 style="margin-top:12px;">גובים חכם, מחייבים מהר</h3>
+      <p class="tagline">תמיכה בחיוב לפי kWh/דקה/חניה, הנחות לחברים, והצעות Bundle לעסקים.</p>
+      <ul class="pill-list">
+        <li>Apple/Google Pay</li>
+        <li>אשראי וחיוב חודשי</li>
+        <li>קודי קופון ודקות טעינה</li>
+        <li>תמחור עומס/שעות שיא</li>
+        <li>חיוב RFID / אפליקציה</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="plans" class="page-content fade-in-on-scroll">
+  <div class="section-heading">חבילות התקנה</div>
+  <h2>מתומחרים ברור – בלי הפתעות</h2>
+  <div class="content-grid">
+    <div class="card">
+      <div class="badge">בית פרטי</div>
+      <h3>פתרון מהיר</h3>
+      <p>עמדת AC 7.4kW, כבל 5 מ', בדיקת חשמלאי מוסמך וחיבור לאפליקציה.</p>
+      <ul class="list-check">
+        <li>התקנה עד 7 ימי עסקים</li>
+        <li>שנת אחריות + ניטור</li>
+        <li>אפשרות חיבור לשע"ח</li>
+      </ul>
+    </div>
+    <div class="card">
+      <div class="badge">עסקים</div>
+      <h3>מודל חכם</h3>
+      <p>2–6 עמדות AC, שליטה מרחוק, Dashboard לחיוב עובדים ואורחים ואינטגרציית הנה"ח.</p>
+      <ul class="list-check">
+        <li>תמחור לפי kWh או זמן</li>
+        <li>מנגנון קנסות זמן-עמידה</li>
+        <li>הדרכת צוות + חומרי מיתוג</li>
+      </ul>
+    </div>
+    <div class="card">
+      <div class="badge">חניונים / מלונות</div>
+      <h3>Revenue Share</h3>
+      <p>הקמת מתחם AC/DC, תמחור דינמי, שירות 24/7 וחלוקת הכנסות שקופה.</p>
+      <ul class="list-check">
+        <li>מודל CAPEX או RevShare</li>
+        <li>לוחות זמנים ו-SLA מוגדרים</li>
+        <li>דוחות שימוש שבועיים ואנליטיקה</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section id="roi" class="page-content fade-in-on-scroll">
+  <div class="two-column">
+    <div>
+      <div class="section-heading">חיזוי הכנסות</div>
+      <h2>מחשבון ROI שמכוון לרווח</h2>
+      <p class="lead-paragraph">הזינו את נפח התנועה והמחירים כדי לראות כמה כסף העמדות שלכם מייצרות בכל חודש. נשתמש בנתונים האלה כדי להתאים תמחור וזרימת משתמש.</p>
+      <ul class="list-check">
+        <li>כולל פקטור תפוסה ומחירי kWh</li>
+        <li>חישוב חודשי + הערכת זמן החזר</li>
+        <li>אפשרות שליחה למומחה להמשך שיחה</li>
+      </ul>
+      <div class="cta-row">
+        <a class="btn-cta" href="#quote">שלחו נתונים וקבלו חישוב מקצועי</a>
+        <a class="btn-secondary" href="tel:0730000000">ייעוץ מיידי</a>
+      </div>
+    </div>
+    <div class="panel calculator">
+      <form id="roiForm" class="calc-form">
+        <div>
+          <label for="sessions">מספר טעינות ביום</label>
+          <input type="number" id="sessions" name="sessions" min="0" value="18">
+        </div>
+        <div>
+          <label for="price">מחיר לחיוב (₪/kWh)</label>
+          <input type="number" id="price" name="price" step="0.1" min="0" value="1.8">
+        </div>
+        <div>
+          <label for="consumption">צריכת kWh ממוצעת לטעינה</label>
+          <input type="number" id="consumption" name="consumption" step="0.5" min="0" value="14">
+        </div>
+        <div>
+          <label for="occupancy">תפוסה / אחוז שימוש</label>
+          <input type="number" id="occupancy" name="occupancy" min="0" max="100" value="65">
+        </div>
+        <div>
+          <label for="cost">עלות תפעול לחודש (₪)</label>
+          <input type="number" id="cost" name="cost" step="100" min="0" value="1200">
+        </div>
+        <div class="full-span">
+          <button type="submit" class="btn-cta" style="width:100%;justify-content:center;">חשב הכנסה</button>
+        </div>
+      </form>
+      <div class="calc-result" id="roiOutput">
+        <div class="result-number">₪ 0</div>
+        <p class="tagline">הכנסה חודשית צפויה לפני מע"מ</p>
+        <p class="pill">נחזיר תשובה מלאה כולל תזרים תוך 24 שעות.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="process" class="page-content fade-in-on-scroll">
+  <div class="section-heading">איך זה עובד</div>
+  <h2>התקנה ותפעול בשלושה צעדים</h2>
+  <div class="steps">
+    <div class="step">
+      <div class="step-number">1</div>
+      <h3>אבחון ושרטוט</h3>
+      <p>איסוף נתוני חשמל ומיקום, סימולציית עומסים והצעת מחיר שקופה עם לוח זמנים.</p>
+    </div>
+    <div class="step">
+      <div class="step-number">2</div>
+      <h3>התקנה חכמה</h3>
+      <p>צוות התקנה מוסמך, בדיקות בטיחות, חיבור OCPP והטמעת מנגנוני חיוב.</p>
+    </div>
+    <div class="step">
+      <div class="step-number">3</div>
+      <h3>הפעלה ומדידה</h3>
+      <p>פתיחת חשבונות משתמש, ניטור, דיווחים תקופתיים ואופטימיזציית הכנסות.</p>
+    </div>
+  </div>
 </section>
 
 <section class="page-content fade-in-on-scroll">
-  <h2>Supported Currencies &amp; Networks</h2>
-  <p>
-    We currently support the following cryptocurrencies and networks:
-  </p>
-  <ul style="line-height:1.8;">
-    <li><strong>Bitcoin (BTC)</strong> – Mainnet</li>
-    <li><strong>Ethereum (ETH)</strong> – ERC-20 on Ethereum mainnet</li>
-    <li><strong>Tether (USDT)</strong> – ERC-20 or TRC-20 (verify beforehand)</li>
-    <li><strong>BNB Chain (optional)</strong> – BEP-20 tokens upon request</li>
-  </ul>
-  <p>
-    For exact details, visit <a href="crypto-payment.html">Crypto Payment</a> or <a href="contact.html">Contact Us</a>.
-  </p>
+  <div class="section-heading">לקוחות מספרים</div>
+  <h2>הוכחות שדה שמייצרות עוד עסקאות</h2>
+  <div class="content-grid testimonials">
+    <div class="card testimonial-card">
+      <p class="tagline">"חניון של 120 מקומות הפך למרכז טעינה מבוקש. קיבלנו דוחות הכנסה שבועיים וראינו עלייה של 2.1x בחיובים."</p>
+      <div class="testimonial-meta">
+        <strong>אורן, מנהל חניון במרכז</strong>
+        <span>מודל RevShare + חיוב דינמי</span>
+      </div>
+    </div>
+    <div class="card testimonial-card">
+      <p class="tagline">"במשרד הוספנו ארבע עמדות AC והמערכת גבתה אוטומטית מהעובדים. התמיכה סגרה כל תקלה בשעה."</p>
+      <div class="testimonial-meta">
+        <strong>דנה, מנהלת תפעול</strong>
+        <span>ניהול משתמשים + דוחות הנה"ח</span>
+      </div>
+    </div>
+    <div class="card testimonial-card">
+      <p class="tagline">"מלון בים המלח מקבל דירוגי שביעות רצון גבוהים אחרי שהוספנו עמדות DC. אורחים מזמינים טעינה מראש באפליקציה."</p>
+      <div class="testimonial-meta">
+        <strong>נעם, בעלים</strong>
+        <span>התקנות DC + אפליקציית אורחים</span>
+      </div>
+    </div>
+  </div>
+  <div class="cta-row" style="margin-top:24px;">
+    <a class="btn-cta" href="#quote">רוצים שנעשה אותו דבר אצלכם?</a>
+    <a class="btn-secondary" href="#roi">בדקו רווחיות</a>
+  </div>
+</section>
+
+<section id="quote" class="page-content fade-in-on-scroll">
+  <div class="two-column">
+    <div>
+      <div class="section-heading">הצעת מחיר</div>
+      <h2>ספרו לנו על הנכס – נקבע התקנה</h2>
+      <p class="lead-paragraph">מלאו את הפרטים ונחזור אליכם עם הצעת מחיר ממוקדת או תיאום סקר אתר. ניתן גם לשריין שיחה עם מומחה בהמשך העמוד.</p>
+      <ul class="list-check">
+        <li>תגובה תוך שעות עבודה.</li>
+        <li>הצעה מותאמת לפי עומסים, מספר חניות וסוג משתמשים.</li>
+        <li>אפשרות למודל RevShare או רכישה מלאה.</li>
+      </ul>
+    </div>
+    <div class="panel">
+      <form action="server/send-form.php" method="POST" class="quote-form">
+        <div>
+          <label for="fullName">שם מלא</label>
+          <input type="text" id="fullName" name="fullName" placeholder="שרה לוי" required>
+        </div>
+        <div>
+          <label for="phone">טלפון</label>
+          <input type="tel" id="phone" name="phone" placeholder="050-1234567" required>
+        </div>
+        <div>
+          <label for="email">אימייל</label>
+          <input type="email" id="email" name="email" placeholder="you@example.com" required>
+        </div>
+        <div>
+          <label for="propertyType">סוג נכס</label>
+          <select id="propertyType" name="propertyType" required>
+            <option value="">בחרו סוג</option>
+            <option value="בית פרטי">בית פרטי</option>
+            <option value="בניין מגורים">בניין מגורים</option>
+            <option value="משרד/עסק">משרד / עסק</option>
+            <option value="חניון/מלון">חניון / מלון</option>
+            <option value="צי רכב">צי רכב</option>
+          </select>
+        </div>
+        <div>
+          <label for="chargerType">הספק/סוג עמדה</label>
+          <select id="chargerType" name="chargerType">
+            <option value="">בחרו</option>
+            <option value="AC 7.4kW">AC 7.4kW</option>
+            <option value="AC 11-22kW">AC 11–22kW</option>
+            <option value="DC 60-120kW">DC 60–120kW</option>
+            <option value="לא בטוח">עדיין לא בטוח</option>
+          </select>
+        </div>
+        <div>
+          <label for="parking">סוג חניה</label>
+          <select id="parking" name="parking">
+            <option value="">בחרו</option>
+            <option value="חניה פרטית">חניה פרטית</option>
+            <option value="חניון משותף">חניון משותף</option>
+            <option value="חניון ציבורי">חניון ציבורי</option>
+            <option value="רחוב">רחוב</option>
+          </select>
+        </div>
+        <div>
+          <label for="timeline">טווח זמנים להקמה</label>
+          <select id="timeline" name="timeline">
+            <option value="">בחרו</option>
+            <option value="מידי">מידי</option>
+            <option value="30 ימים">30 ימים</option>
+            <option value="רבעון הקרוב">רבעון הקרוב</option>
+          </select>
+        </div>
+        <div class="full-span">
+          <label for="notes">הערות / כמות עמדות</label>
+          <textarea id="notes" name="notes" placeholder="מספר עמדות, מיקום מדויק, מגבלות חשמל"></textarea>
+        </div>
+        <div class="full-span" style="display:flex;align-items:center;gap:8px;">
+          <input type="checkbox" id="consent" name="consent" required style="width:auto;">
+          <label for="consent" style="margin:0;">אני מאשר/ת קבלת פרטי הצעה ויצירת קשר מצד EVcharge</label>
+        </div>
+        <div class="full-span">
+          <button type="submit" class="btn-cta" style="width:100%; justify-content:center;">שלחו לי הצעה</button>
+        </div>
+      </form>
+      <p class="tagline">מעוניינים בשיחה? כתבו בהערות שעה מועדפת או שלחו מייל ל-hello@evcharge.co.il</p>
+    </div>
+  </div>
 </section>
 
 <section class="page-content fade-in-on-scroll">
-  <h2>Community &amp; Fair Play</h2>
-  <p>
-    We believe in building a vibrant community of passionate poker players.
-    <br>
-    <strong>Fairness</strong> is central to our operation: no cheating, chip dumping, 
-    or collusion is tolerated. Our security measures and manual checks ensure a balanced field.
-  </p>
+  <div class="panel" style="text-align:center;">
+    <div class="section-heading">תמיכה ושירות</div>
+    <h2>נשארים לצדכם אחרי ההתקנה</h2>
+    <p class="lead-paragraph" style="margin:12px auto 0;">ממשיכים לנטר, לדווח ולשפר את הכנסות הנכס לאורך זמן. שירותי תחזוקה מונעת, מוקד 24/7 ואפשרות לביטוח ציוד.</p>
+    <div class="cta-row" style="justify-content:center;">
+      <a class="btn-cta" href="#quote">קבלו הצעת שירות</a>
+      <a class="btn-secondary" href="#top">חזרה לראש הדף</a>
+    </div>
+  </div>
 </section>
+
+<div class="sticky-cta-bar">
+  <div>
+    <strong>הפכו את החניה למכונת הכנסה.</strong>
+    <span class="response-tag">תגובה עד 60 דקות</span>
+  </div>
+  <div class="cta-row" style="gap:10px;">
+    <a class="btn-cta" href="#quote">סגרו התקנה</a>
+    <a class="btn-secondary" href="contact.html">תיאום שיחה</a>
+    <a class="btn-secondary" href="tel:0730000000">073-000-0000</a>
+  </div>
+</div>
 
 <footer>
-  <div style="text-align:center; padding: 20px; background-color: #111;">
-    <p>&copy; 2025 Golden Ace Poker Club. All rights reserved.</p>
-    <p>Powered by <strong>ClubGG</strong> | <a href="contact.html" style="color:#ffd700;">Contact Support</a></p>
+  <div style="text-align:center; padding: 20px; background-color: #0f1621; border-top:1px solid var(--border);">
+    <p>&copy; 2025 EVcharge.co.il. כל הזכויות שמורות.</p>
+    <p>פתרונות טעינה חכמים לבית, לעסק ולחניונים | <a href="#quote" style="color: var(--accent); text-decoration:none;">דברו איתנו</a></p>
     <p>
-      <a href="index.html" style="color:#fff; margin-right:10px;">Home</a> | 
-      <a href="join-club.html" style="color:#fff; margin-right:10px;">Join Now</a> | 
-      <a href="faq.html" style="color:#fff; margin-right:10px;">FAQ</a> | 
-      <a href="terms.html" style="color:#fff;">Terms</a>
+      <a href="#top" style="color:#fff; margin-right:10px;">בית</a> |
+      <a href="#solutions" style="color:#fff; margin-right:10px;">פתרונות</a> |
+      <a href="#plans" style="color:#fff; margin-right:10px;">חבילות</a> |
+      <a href="#quote" style="color:#fff;">צור קשר</a>
     </p>
   </div>
 </footer>
 
-<!-- כפתור חזרה למעלה -->
 <button id="backToTopBtn" title="Go to top">↑</button>
 
 <script src="js/script.js"></script>

--- a/אתר/js/script.js
+++ b/אתר/js/script.js
@@ -44,3 +44,43 @@ window.addEventListener('load', () => {
     // they fade in automatically by CSS keyframes
   });
 });
+
+// ROI Calculator
+const roiForm = document.getElementById('roiForm');
+const roiOutput = document.getElementById('roiOutput');
+
+if (roiForm && roiOutput) {
+  const resultNumber = roiOutput.querySelector('.result-number');
+  const tagline = roiOutput.querySelector('.tagline');
+  const pill = roiOutput.querySelector('.pill');
+
+  const formatMoney = (value) => new Intl.NumberFormat('he-IL', { maximumFractionDigits: 0 }).format(value);
+
+  const calculate = () => {
+    const sessions = parseFloat(roiForm.sessions.value) || 0;
+    const price = parseFloat(roiForm.price.value) || 0;
+    const consumption = parseFloat(roiForm.consumption.value) || 0;
+    const occupancy = Math.min(Math.max(parseFloat(roiForm.occupancy.value) || 0, 0), 100) / 100;
+    const cost = parseFloat(roiForm.cost.value) || 0;
+
+    const gross = sessions * price * consumption * 30 * occupancy;
+    const net = Math.max(gross - cost, 0);
+    const payback = gross > 0 ? Math.max((cost * 4) / Math.max(net, 1), 0) : 0;
+
+    resultNumber.textContent = `₪ ${formatMoney(net)}`;
+    if (tagline) {
+      tagline.textContent = `הכנסה חודשית צפויה לפני מע"מ לאחר עלויות תפעול (${formatMoney(cost)} ₪).`;
+    }
+    if (pill) {
+      pill.textContent = `החזר השקעה משוער: ${payback.toFixed(1)} חודשים בהיקף ההתקנות הנוכחי.`;
+    }
+  };
+
+  roiForm.addEventListener('input', calculate);
+  roiForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    calculate();
+  });
+
+  calculate();
+}


### PR DESCRIPTION
## Summary
- Add revenue-focused CTA strips, "מכונת הכנסה" section, testimonials, and sticky bottom CTA to the EVcharge home page
- Introduce ROI calculator experience plus supporting styling updates for grids, cards, and conversion components
- Expand the contact page with an urgent CTA strip and a fast-call scheduling form

## Testing
- Not run (static content)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939da1af57883279300c784adb4e044)